### PR TITLE
Footer style tweak

### DIFF
--- a/app/javascript/entrypoints/application.scss
+++ b/app/javascript/entrypoints/application.scss
@@ -11,3 +11,8 @@
 @import "../css/layout";
 @import "../css/form";
 
+@layer components {
+  .debug {
+    @apply border border-red-200;
+  }
+}

--- a/app/views/application/_footer.html.erb
+++ b/app/views/application/_footer.html.erb
@@ -1,4 +1,4 @@
-<footer class="mb-12 mt-16">
+<footer class="mb-12 mt-16 mx-auto">
   <div class="max-w-6xl mx-auto px-4 sm:px-6">
     <div class="col-span-12 lg:col-span-4 order-1 lg:order-none text-center">
       <div class="h-full flex flex-col sm:flex-row lg:flex-col justify-between">


### PR DESCRIPTION
Hey Eric! Congrats on the new personal site—I absolutely love it!

Made a tiny style tweak to the footer to ensure it's centered on smaller screens.

Also included a helpful Tailwind directive for debugging styles that I recently learned about on [Twitter/X](https://twitter.com/thekitze/status/1769067843549553032)

<img width="1024" alt="before_center" src="https://github.com/coderberry/berry/assets/6802326/32cdd466-43c3-4d41-8ad0-081588c3f6cd">
<img width="1104" alt="after_center" src="https://github.com/coderberry/berry/assets/6802326/500cbc39-820b-43b6-9a08-be735248cb14">
